### PR TITLE
Fix link to live demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ There are several existing JavaScript implementations of the Jinja family of tem
 
 
 [docs]: docs/guide.md
-[demo]: http://sstur.com/jinja-js/demo/
+[demo]: http://sstur.github.io/jinja-js/demo/
 [django]: http://docs.djangoproject.com/en/dev/ref/templates/builtins/
 [liquid]: http://liquidmarkup.org/
 [twig]: http://twig.sensiolabs.org/


### PR DESCRIPTION
Replace http://sstur.com/jinja-js/demo/ with http://sstur.github.io/jinja-js/demo/
